### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/LawnGnome/mojique/compare/v0.1.0...v0.1.1) - 2025-07-19
+
+### Fixed
+
+- revert release-plz configuration
+- README heading formatting
+
+### Other
+
+- fix README
+- configure release-plz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "mojique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mojique"
-version = "0.1.0"
+version = "0.1.1"
 description = "A safe Rust wrapper and pool implementation around libmagic"
 license = "MIT"
 repository = "https://github.com/LawnGnome/mojique"


### PR DESCRIPTION



## 🤖 New release

* `mojique`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/LawnGnome/mojique/compare/v0.1.0...v0.1.1) - 2025-07-19

### Fixed

- revert release-plz configuration
- README heading formatting

### Other

- fix README
- configure release-plz
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).